### PR TITLE
Fixed Results Panel Shifting Bug

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -104,13 +104,6 @@ const App: React.FC = () => {
         }
     }, [responseObject]);
 
-    useEffect(() => {
-        // When a place is selected from the map or list, ensure the results panel is visible.
-        if (selectedPlaceId) {
-            setIsRightPanelCollapsed(false);
-        }
-    }, [selectedPlaceId]);
-
     const handleShapeUpdateFromMap = useCallback((
         locType: 'bias' | 'restriction',
         shape: 'circle' | 'rectangle' | null,
@@ -267,7 +260,7 @@ const App: React.FC = () => {
     }, [setRequest]);
 
     return (
-        <div className="w-screen h-screen relative overflow-x-hidden">
+        <div className="fixed inset-0 overflow-hidden">
             <div className="absolute inset-0 z-0">
                  <MapComponent 
                     apiKey={mapApiKey} 
@@ -350,6 +343,7 @@ const App: React.FC = () => {
                                     markers={markers}
                                     selectedPlaceId={selectedPlaceId}
                                     onSelectPlace={setSelectedPlaceId}
+                                    isCollapsed={isRightPanelCollapsed}
                                 />
                             </div>
                         </div>

--- a/components/ResultsPanel.tsx
+++ b/components/ResultsPanel.tsx
@@ -8,79 +8,93 @@ interface ResultsPanelProps {
     markers: MarkerData[];
     selectedPlaceId: string | null;
     onSelectPlace: (placeId: string | null) => void;
+    isCollapsed: boolean;
 }
 
-const ResultsPanel: React.FC<ResultsPanelProps> = ({ responseObject, curlCommand, markers, selectedPlaceId, onSelectPlace }) => {
+const ResultsPanel: React.FC<ResultsPanelProps> = ({ responseObject, curlCommand, markers, selectedPlaceId, onSelectPlace, isCollapsed }) => {
     const preRef = useRef<HTMLPreElement>(null);
     const selectedItemRef = useRef<HTMLDivElement>(null);
     const focusProps = useFocusRing();
-    
+    const prevSelectedPlaceIdRef = useRef<string | null>(null);
+    const listContainerRef = useRef<HTMLDivElement>(null);
+    const jsonContainerRef = useRef<HTMLDivElement>(null);
+
     useEffect(() => {
+        const prevSelected = prevSelectedPlaceIdRef.current;
+        prevSelectedPlaceIdRef.current = selectedPlaceId;
+
+        if (isCollapsed) return;
+        if (!selectedPlaceId || selectedPlaceId === prevSelected) return;
         if (selectedItemRef.current) {
             selectedItemRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }
-    }, [selectedPlaceId]);
-    
+    }, [selectedPlaceId, isCollapsed]);
+
+    useEffect(() => {
+        if (listContainerRef.current) {
+            listContainerRef.current.scrollTop = 0;
+        }
+        if (jsonContainerRef.current) {
+            jsonContainerRef.current.scrollTop = 0;
+        }
+    }, [responseObject, markers]);
+
     useEffect(() => {
         if (!preRef.current) return;
         const fullJsonString = responseObject ? JSON.stringify(responseObject, null, 2) : '(no response yet)';
+        let highlightedHtml: string | null = null;
 
-        if (!selectedPlaceId || !responseObject?.suggestions) {
-            preRef.current.textContent = fullJsonString;
-            return;
-        }
+        if (selectedPlaceId && responseObject?.suggestions) {
+            const selectedSuggestion = responseObject.suggestions.find(
+                (s: any) => s.placePrediction?.placeId === selectedPlaceId
+            );
 
-        const selectedSuggestion = responseObject.suggestions.find(
-            (s: any) => s.placePrediction?.placeId === selectedPlaceId
-        );
+            if (selectedSuggestion) {
+                const placeIdStr = `"placeId": "${selectedPlaceId}"`;
+                const placeIdIndex = fullJsonString.indexOf(placeIdStr);
 
-        if (!selectedSuggestion) {
-            preRef.current.textContent = fullJsonString;
-            return;
-        }
+                if (placeIdIndex !== -1) {
+                    const ppKey = '"placePrediction": {';
+                    const startIndex = fullJsonString.lastIndexOf(ppKey, placeIdIndex);
 
-        // Find start of placePrediction object. It's inside a suggestion object.
-        const placeIdStr = `"placeId": "${selectedPlaceId}"`;
-        const placeIdIndex = fullJsonString.indexOf(placeIdStr);
-        if (placeIdIndex === -1) {
-            preRef.current.textContent = fullJsonString;
-            return;
-        }
+                    if (startIndex !== -1) {
+                        let openBraces = 1;
+                        let endIndex = -1;
+                        for (let i = startIndex + ppKey.length; i < fullJsonString.length; i++) {
+                            if (fullJsonString[i] === '{') openBraces++;
+                            else if (fullJsonString[i] === '}') openBraces--;
 
-        const ppKey = '"placePrediction": {';
-        const startIndex = fullJsonString.lastIndexOf(ppKey, placeIdIndex);
-        if (startIndex === -1) {
-            preRef.current.textContent = fullJsonString;
-            return;
-        }
+                            if (openBraces === 0) {
+                                endIndex = i;
+                                break;
+                            }
+                        }
 
-        // Find matching closing brace
-        let openBraces = 1;
-        let endIndex = -1;
-        for (let i = startIndex + ppKey.length; i < fullJsonString.length; i++) {
-            if (fullJsonString[i] === '{') openBraces++;
-            else if (fullJsonString[i] === '}') openBraces--;
-            
-            if (openBraces === 0) {
-                endIndex = i;
-                break;
+                        if (endIndex !== -1) {
+                            const escapeHtml = (unsafe: string) =>
+                                unsafe
+                                    .replace(/&/g, "&amp;")
+                                    .replace(/</g, "&lt;")
+                                    .replace(/>/g, "&gt;")
+                                    .replace(/"/g, "&quot;")
+                                    .replace(/'/g, "&#039;");
+
+                            const before = escapeHtml(fullJsonString.substring(0, startIndex));
+                            const target = escapeHtml(fullJsonString.substring(startIndex, endIndex + 1));
+                            const after = escapeHtml(fullJsonString.substring(endIndex + 1));
+
+                            highlightedHtml = `${before}<span class="bg-yellow-200 block rounded">${target}</span>${after}`;
+                        }
+                    }
+                }
             }
         }
 
-        if (endIndex === -1) {
+        if (highlightedHtml) {
+            preRef.current.innerHTML = highlightedHtml;
+        } else {
             preRef.current.textContent = fullJsonString;
-            return;
         }
-        
-        const escapeHtml = (unsafe: string) => unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
-
-        const before = escapeHtml(fullJsonString.substring(0, startIndex));
-        const target = escapeHtml(fullJsonString.substring(startIndex, endIndex + 1));
-        const after = escapeHtml(fullJsonString.substring(endIndex + 1));
-        
-        const highlightedHtml = `${before}<span class="bg-yellow-200 block rounded">${target}</span>${after}`;
-        preRef.current.innerHTML = highlightedHtml;
-
     }, [responseObject, selectedPlaceId]);
 
     const copyToClipboard = (text: string) => {
@@ -98,7 +112,7 @@ const ResultsPanel: React.FC<ResultsPanelProps> = ({ responseObject, curlCommand
             {markers.length > 0 && (
                 <div>
                     <h4 className="text-base font-semibold mb-2">Places Found</h4>
-                    <div className="max-h-60 overflow-auto border border-gray-200 rounded-lg">
+                    <div ref={listContainerRef} className="max-h-60 overflow-auto border border-gray-200 rounded-lg">
                         <div className="inline-block min-w-full align-top">
                             {markers.map((marker) => (
                                 <div
@@ -129,10 +143,10 @@ const ResultsPanel: React.FC<ResultsPanelProps> = ({ responseObject, curlCommand
                     </div>
                 </div>
             )}
-            
+
             <div>
                 <h4 className="text-base font-semibold mb-2">Autocomplete Response</h4>
-                <div className="max-h-72 overflow-auto bg-gray-100 rounded-lg border border-gray-200">
+                <div ref={jsonContainerRef} className="max-h-72 overflow-auto bg-gray-100 rounded-lg border border-gray-200">
                     <div className="inline-block min-w-full">
                         <pre ref={preRef} className="p-2.5 text-xs font-mono whitespace-pre">
                             {/* Content will be set by useEffect */}
@@ -147,9 +161,9 @@ const ResultsPanel: React.FC<ResultsPanelProps> = ({ responseObject, curlCommand
                     <pre className="whitespace-pre max-h-48 overflow-auto bg-gray-800 text-gray-200 p-3 rounded-lg text-xs font-mono">
                         {curlCommand}
                     </pre>
-                    <button 
+                    <button
                         {...focusProps}
-                        onClick={() => copyToClipboard(curlCommand)} 
+                        onClick={() => copyToClipboard(curlCommand)}
                         className="mt-2 bg-blue-600 text-white font-semibold py-1.5 px-3 rounded-md text-sm hover:bg-blue-700 transition focus:outline-none">
                         Copy cURL
                     </button>


### PR DESCRIPTION
Removed the behavior of the results panel where its automatically expanding when a marker is selected while its collapsed. The shifting of the page when the results panel is expanded bug also got resolved.