### PR TITLE
Ensure markers are visible + clean up

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -44,6 +44,7 @@ const App: React.FC = () => {
     const [submittedRequest, setSubmittedRequest] = useState<AutocompleteRequest | null>(null);
     const [hasBeenCleared, setHasBeenCleared] = useState<boolean>(false);
     const [isPlacingOrigin, setIsPlacingOrigin] = useState<boolean>(false);
+    const [shouldFitBounds, setShouldFitBounds] = useState<boolean>(false);
     const prevInputRef = useRef<string>(initialRequest.input);
 
     const [isLeftPanelCollapsed, setIsLeftPanelCollapsed] = useState(false);
@@ -232,6 +233,7 @@ const App: React.FC = () => {
                 const resolvedMarkers = await Promise.all(markerPromises);
                 const newMarkers = resolvedMarkers.filter((marker): marker is MarkerData => marker !== null);
                 setMarkers(newMarkers);
+                setShouldFitBounds(true);
             }
 
         } catch (error: any) {
@@ -277,6 +279,10 @@ const App: React.FC = () => {
                     isPlacingOrigin={isPlacingOrigin}
                     setIsPlacingOrigin={setIsPlacingOrigin}
                     onOriginUpdate={handleOriginUpdate}
+                    isLeftPanelCollapsed={isLeftPanelCollapsed}
+                    isRightPanelCollapsed={isRightPanelCollapsed}
+                    shouldFitBounds={shouldFitBounds}
+                    onFitBoundsComplete={() => setShouldFitBounds(false)}
                  />
             </div>
             

--- a/types.ts
+++ b/types.ts
@@ -1,8 +1,3 @@
-
-
-
-
-
 // FIX: To fix "Cannot find name 'google'" and "Cannot find namespace 'google'" errors,
 // the `google` namespace declaration is moved inside `declare global` to make it available in all files.
 declare global {

--- a/utils/geoUtils.ts
+++ b/utils/geoUtils.ts
@@ -1,4 +1,3 @@
-
 import { Rectangle, Circle } from '../types';
 
 export const pointInRect = (lat: number, lng: number, rect: Rectangle): boolean => {

--- a/utils/mapMarkerUtils.ts
+++ b/utils/mapMarkerUtils.ts
@@ -1,4 +1,3 @@
-
 interface SvgMarkerOptions {
     color?: string;
     size?: number;


### PR DESCRIPTION
After sending a request, all the results or markers are ensured to be displayed within the visible part of the map (the part where the map is not obstructed by the side panels).

When a place is selected through the place lists in the Results panel, the selected place and it's marker are guaranteed to be positioned in the unobstructed part of the map as well.

Cleaned up empty lines.